### PR TITLE
fix: ensure "war" and "howard" do not overlap

### DIFF
--- a/src/responses.ts
+++ b/src/responses.ts
@@ -253,7 +253,7 @@ export const burnResponses: Response[] = [
   {
     keyword: 'war',
     description: 'IT Crowd - I am declaring war',
-    listen: /war/i,
+    listen: /\b(war)\b/i,
     play: 'it-crowd-i-am-declaring-war.mp3',
   },
   {


### PR DESCRIPTION
Using full word match regex for "war".

```js
// returns null
'howard'.match(/\b(war)\b/)

// matches
'war'.match(/\b(war)\b/)
```